### PR TITLE
Database updates to allow pure discord setup

### DIFF
--- a/db/migrate/20250418135406_items_add_status.rb
+++ b/db/migrate/20250418135406_items_add_status.rb
@@ -1,0 +1,15 @@
+class ItemsAddStatus < ActiveRecord::Migration[8.0]
+  def change
+    type_name = "item_status"
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::NATIVE_DATABASE_TYPES[type_name.to_sym] = { name: type_name }
+    reversible do |dir|
+      dir.up do
+        execute "CREATE TYPE #{type_name} AS ENUM ('claimed', 'help', 'box')"
+      end
+      dir.down do
+        execute "DROP TYPE #{type_name}"
+      end
+    end
+    add_column :items, :status, type_name.to_sym
+  end
+end

--- a/db/migrate/20250531002256_create_team_integrations.rb
+++ b/db/migrate/20250531002256_create_team_integrations.rb
@@ -1,0 +1,10 @@
+class CreateTeamIntegrations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :team_integrations do |t|
+      t.references :team, null: false, foreign_key: true
+      t.jsonb :integration_data, index: {unique: true}
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250531003154_optional_team_prefix.rb
+++ b/db/migrate/20250531003154_optional_team_prefix.rb
@@ -1,0 +1,6 @@
+class OptionalTeamPrefix < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :teams, :prefix, true
+    change_column_null :team_scav_hunts, :scav_hunt_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_03_221412) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_31_003154) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -110,6 +110,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_03_221412) do
     t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
+  create_table "team_integrations", force: :cascade do |t|
+    t.bigint "team_id", null: false
+    t.jsonb "integration_data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["integration_data"], name: "index_team_integrations_on_integration_data", unique: true
+    t.index ["team_id"], name: "index_team_integrations_on_team_id"
+  end
+
   create_table "team_role_members", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "team_scav_hunt_id", null: false
@@ -133,7 +142,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_03_221412) do
 
   create_table "team_scav_hunts", force: :cascade do |t|
     t.text "name", null: false
-    t.bigint "scav_hunt_id", null: false
+    t.bigint "scav_hunt_id"
     t.bigint "team_id", null: false
     t.text "discord_guild_id"
     t.text "discord_items_channel_id"
@@ -178,7 +187,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_03_221412) do
 
   create_table "teams", force: :cascade do |t|
     t.text "affiliation", null: false
-    t.text "prefix", null: false
+    t.text "prefix"
     t.boolean "virtual", null: false
     t.boolean "uchicago", null: false
     t.datetime "created_at", null: false
@@ -208,6 +217,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_03_221412) do
   add_foreign_key "page_captains", "users"
   add_foreign_key "pages", "team_scav_hunts"
   add_foreign_key "sessions", "users"
+  add_foreign_key "team_integrations", "teams"
   add_foreign_key "team_role_members", "team_roles"
   add_foreign_key "team_role_members", "team_scav_hunts"
   add_foreign_key "team_role_members", "users"


### PR DESCRIPTION
Item status table is a bit of a legacy thing I was playing with back in April, but it seems it'll get used ultimately so I'm keeping it for now. TeamIntegrations is named as such because I intend to make all the discord_* stuff to be made agnostic and get an "integration_type" column. The null on teams.prefix is for discord only teams, TeamIntegrations is for team ownership to allow discord only teams to still be managed, and the team_scav_hunts.scav_hunt_id null is for testing hunts. None of these will immediately require web changes, but they'll probably want to all be able to be edited web side. For example, the null scav_hunt_id will probably break URL gen, the null prefix will be inaccessible (which is fine, no changes required), and the integration will need to be able to be modified web site so that ownership can be fully managed web side instead of discord.

ref https://github.com/Scavinator/scavinator-discord/pull/2